### PR TITLE
baseURL moved to config

### DIFF
--- a/src-spa/quasar.conf.js
+++ b/src-spa/quasar.conf.js
@@ -90,8 +90,8 @@ module.exports = function (ctx) {
       env: {
         api: JSON.stringify(
           ctx.dev
-            ? 'http://localhost/api' // local dev env
-            : 'http://prod.tld/api' // production end-point
+            ? 'http://localhost' // local dev env
+            : 'https://stagebackoffice.worldsoft.com.sg' // production end-point
         )
       }
     },

--- a/src-spa/src/boot/axios.js
+++ b/src-spa/src/boot/axios.js
@@ -3,14 +3,14 @@ import store from '../store'
 
 export default async ({ Vue }) => {
   Vue.prototype.$axios = axios
-  // Vue.prototype.$axios.defaults.withCredentials = true
 
   const token = localStorage.getItem('token')
   if (token) {
     Vue.prototype.$axios.defaults.headers.common['Authorization'] = 'Bearer ' + token
   }
 
-  const baseURL = 'http://localhost'
+  const baseURL = process.env.api
+  console.log('BASE URL:' + baseURL)
   if (typeof baseURL !== 'undefined') {
     Vue.prototype.$axios.defaults.baseURL = baseURL
   }


### PR DESCRIPTION
baseUrl defined in quasar.conf.js in "build" > "env" > "api" block -- now it accessible using var process.env.api